### PR TITLE
PHP 8.1 & Firebase JWT 6 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,13 +10,13 @@
     }
   ],
   "require": {
-    "firebase/php-jwt": "^5.0.0",
-    "nesbot/carbon": "^1.9.0",
-    "ramsey/uuid": "^3.7.3"
+    "firebase/php-jwt": "^6.0.0",
+    "nesbot/carbon": "^2.70.0",
+    "ramsey/uuid": "^4.7.4"
   },
   "require-dev": {
-    "phpunit/phpunit": "~3.7",
-    "silverstripe/sqlite3": "^1.4.0"
+    "phpunit/phpunit": "^9.6.12",
+    "silverstripe/sqlite3": "^3.0.0"
   },
   "autoload": {
       "psr-4": {

--- a/tests/JWTUtilsTest.yml
+++ b/tests/JWTUtilsTest.yml
@@ -2,3 +2,4 @@ Member:
   valid-member:
     Email: test@test.test
     Password: my-test-password
+    PasswordEncryption: none


### PR DESCRIPTION
Adds PHP 8.1 compatibility and an upgrade to `firebase/php-jwt` to >=6.0.0 to address a Sev 9.1 vulnerability.